### PR TITLE
Adjustments to Edit and Signin Pages

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,6 +12,7 @@ import AlertState from "./context/AlertState"
 import setAuthToken from './components/utils/setAuthToken'
 
 import PrivateRoute from "./routing/PrivateRoute"
+import LoginRoute from "./routing/LoginRoute"
 import Main from './pages/Main';
 import About from './pages/About';
 import Sculptures from "./pages/Sculptures"
@@ -52,8 +53,8 @@ function App() {
                     <Route exact path="/gallery" component={Gallery} />
                     <Route exact path="/contact" component={Contact} />
                     <Route exact path="/cart" component={Cart} />
-                    <Route exact path="/signin" component={Login} />
-                    <PrivateRoute exact path="/edit" component={Edit} />  
+                    <LoginRoute exact path="/signin" component={Login} />
+                    <PrivateRoute exact path="/edit*" component={Edit} />  
                     <Route exact path="/" component={Main} />      
                   </Switch>
                   <Footer />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -52,7 +52,7 @@ function App() {
                     <Route exact path="/gallery" component={Gallery} />
                     <Route exact path="/contact" component={Contact} />
                     <Route exact path="/cart" component={Cart} />
-                    <Route exact path="/login" component={Login} />
+                    <Route exact path="/signin" component={Login} />
                     <PrivateRoute exact path="/edit" component={Edit} />  
                     <Route exact path="/" component={Main} />      
                   </Switch>

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -69,7 +69,7 @@ const Header = () => {
                     badgeContent={cartItems} 
                     style={{
                       color: "var(--medium)", 
-                      backgroundColor: "var(--medium", 
+                      backgroundColor: "var(--medium)", 
                       }}
                   >
                     <ShoppingCartOutlinedIcon 
@@ -83,7 +83,7 @@ const Header = () => {
               </li>
               
               <li onClick={() => setOpen(false)}>
-                <Link to="/login" className="login-edit">
+                <Link to="/edit" className="login-edit">
                   {isAuthenticated ?
                     <EditIcon 
                       style={{position: "relative", top: "4px"}}  

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -86,13 +86,13 @@ const Header = () => {
                 <Link to="/edit" className="login-edit">
                   {isAuthenticated ?
                     <EditIcon 
-                      style={{position: "relative", top: "4px"}}  
+                      style={{position: "relative", top: "6px"}}  
                     /> : 
                     <ExitToAppIcon 
                       style={{
                         color: "var(--light-two)", 
                         position: "relative", 
-                        top: "5px"
+                        top: "6px"
                         }}
                     />}
                 </Link>

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -47,31 +47,31 @@ const Edit = () => {
 
                     <PageHeader heading="Edit Your content" />
                     <div className="nav-buttons">
-                        <Link to="/uploadgallery">
+                        <Link to="/edit/uploadgallery">
                             <button 
-                                style={page === "/uploadgallery" ? style : null}
+                                style={page === "/edit/uploadgallery" ? style : null}
                                 name="/uploadgallery" 
                                 onClick={changePage}>NEW Gallery
                             </button>
                         </Link>
-                        <Link to="/uploadprint">
+                        <Link to="/edit/uploadprint">
                             <button 
-                                style={page === "/uploadprint" ? style : null}
-                                name="/uploadprint" 
+                                style={page === "/edit/uploadprint" ? style : null}
+                                name="/edit/uploadprint" 
                                 onClick={changePage}>NEW Store
                             </button>
                         </Link>
-                        <Link to="/updatestock">
+                        <Link to="/edit/updatestock">
                             <button 
-                                style={page === "/updatestock" ? style : null}
-                                name="/updatestock" 
+                                style={page === "/edit/updatestock" ? style : null}
+                                name="/edit/updatestock" 
                                 onClick={changePage}>Edit Store
                             </button>
                         </Link>
-                        <Link to="/editgallery">
+                        <Link to="/edit/editgallery">
                             <button 
-                                style={page === "/editgallery" ? style : null}
-                                name="/editgallery" 
+                                style={page === "/edit/editgallery" ? style : null}
+                                name="/edit/editgallery" 
                                 onClick={changePage}>Edit Gallery
                             </button>
                         </Link>
@@ -84,10 +84,10 @@ const Edit = () => {
                             timeout={200}
                         >
                             <Switch location={location}>
-                                <Route exact path="/uploadgallery" component={UploadGallery}/>
-                                <Route exact path="/uploadprint" component={UploadPrint}/>
-                                <Route exact path="/updatestock" component={UpdateStock}/>
-                                <Route exact path="/editgallery" component={EditGallery}/>
+                                <Route exact path="/edit/uploadgallery" component={UploadGallery}/>
+                                <Route exact path="/edit/uploadprint" component={UploadPrint}/>
+                                <Route exact path="/edit/updatestock" component={UpdateStock}/>
+                                <Route exact path="/edit/editgallery" component={EditGallery}/>
                             </Switch>
                         </CSSTransition>
                     </TransitionGroup>     

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -1,21 +1,23 @@
 import React, { useContext, useEffect, useState } from 'react'
+import {Router, Switch, Route, Link} from 'react-router-dom';
+import {createBrowserHistory} from 'history'
+
 import "../styles/edit.css"
+
 import AppContext from "../context/AppContext"
 import AuthContext from "../context/authContext"
+
 import UploadGallery from '../components/UploadGallery'
 import UpdateStock from '../components/UpdateStock'
 import UploadPrint from "../components/UploadPrint"
 import EditGallery from "../components/EditGallery"
-import Alerts from "../components/Alerts"
-import { Fab } from '@material-ui/core';
-
-import {CSSTransition, TransitionGroup} from "react-transition-group";
-import {Router, Switch, Route, Link} from 'react-router-dom';
-import {createBrowserHistory} from 'history'
 import PageHeader from '../components/PageHeader'
+import Alerts from "../components/Alerts"
+
+import { Fab } from '@material-ui/core';
+import {CSSTransition, TransitionGroup} from "react-transition-group";
 
 const history = createBrowserHistory();
-
 
 const Edit = () => {
     const authContext = useContext(AuthContext)

--- a/client/src/pages/Edit.js
+++ b/client/src/pages/Edit.js
@@ -50,7 +50,7 @@ const Edit = () => {
                         <Link to="/edit/uploadgallery">
                             <button 
                                 style={page === "/edit/uploadgallery" ? style : null}
-                                name="/uploadgallery" 
+                                name="/edit/uploadgallery" 
                                 onClick={changePage}>NEW Gallery
                             </button>
                         </Link>

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -1,4 +1,4 @@
-import React, {useContext, useState, useEffect, useRef} from 'react'
+import React, {useContext, useState, useEffect, useRef, useLayoutEffect} from 'react'
 import PageHeader from '../components/PageHeader';
 import AuthContext from "../context/authContext"
 import Alerts from "../components/Alerts"
@@ -16,7 +16,7 @@ const Login = (props) => {
     const [showPassword, setShowPassword] = useState(false)
     const passwordInput = useRef()
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         if(isAuthenticated) {
             props.history.push("/edit")
         }

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -1,4 +1,4 @@
-import React, {useContext, useState, useEffect, useRef, useLayoutEffect} from 'react'
+import React, {useContext, useState, useEffect, useRef} from 'react'
 import PageHeader from '../components/PageHeader';
 import AuthContext from "../context/authContext"
 import Alerts from "../components/Alerts"
@@ -11,16 +11,10 @@ const Login = (props) => {
     const alertContext = useContext(AlertContext)
     const {setAlert} = alertContext
     const authContext = useContext(AuthContext)
-    const {isAuthenticated, login, errors} = authContext;
+    const {login, errors} = authContext;
     const [password, setPassword] = useState("")
     const [showPassword, setShowPassword] = useState(false)
     const passwordInput = useRef()
-
-    useLayoutEffect(() => {
-        if(isAuthenticated) {
-            props.history.push("/edit")
-        }
-    }, [isAuthenticated, props.history])
 
     useEffect(() => {
         errors.forEach(err => {

--- a/client/src/routing/LoginRoute.js
+++ b/client/src/routing/LoginRoute.js
@@ -1,0 +1,18 @@
+import React, {useContext} from 'react';
+import {Route, Redirect} from "react-router-dom";
+import AuthContext from "../context/authContext"
+
+const LoginRoute = ({component: Component, ...rest}) => {
+    const authContext = useContext(AuthContext);
+    const {isAuthenticated} = authContext;
+    return (
+        <Route {...rest} render={props => isAuthenticated && localStorage.token ? (
+            <Redirect to="/edit" /> 
+        ) : (
+            <Component {...props} />
+        )}
+        />
+    )
+}
+
+export default LoginRoute

--- a/client/src/routing/PrivateRoute.js
+++ b/client/src/routing/PrivateRoute.js
@@ -8,7 +8,7 @@ const PrivateRoute = ({component: Component, ...rest}) => {
 
     return (
         <Route {...rest} render={props => !isAuthenticated && !localStorage.token ? (
-            <Redirect to="/login" />
+            <Redirect to="/signin" />
         ) : (
             <Component {...props} />
         )}

--- a/client/src/styles/edit.css
+++ b/client/src/styles/edit.css
@@ -34,6 +34,7 @@
 .nav-buttons button {
   width: 100%;
   padding: 1rem 2rem;
+  margin: 0;
   border: none;
   background-color: inherit;
   color: var(--dark);
@@ -360,6 +361,10 @@
 
   .nav-buttons button {
     padding: 0.5rem;
+  }
+
+  .nav-buttons a {
+    flex-basis: 25%;
   }
 
   .upload-form textarea {

--- a/client/src/styles/edit.css
+++ b/client/src/styles/edit.css
@@ -22,6 +22,7 @@
   right: 1rem;
   top: 50%;
   transform: translateY(-50%);
+  cursor: pointer;
 }
 
 .nav-buttons {

--- a/client/src/styles/keyframes.css
+++ b/client/src/styles/keyframes.css
@@ -10,7 +10,7 @@
     transform: scale(0.95);
   }
   100% {
-    text-shadow: none;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.7);
     transform: scale(1);
   }
 }

--- a/client/src/styles/navbar.css
+++ b/client/src/styles/navbar.css
@@ -42,6 +42,10 @@ header li:last-of-type {
   margin-right: 0.8rem;
 }
 
+header li:last-of-type a:active {
+  animation: press 100ms ease;
+}
+
 header a {
   box-shadow: none;
   transition: all 150ms linear;
@@ -96,8 +100,10 @@ header .cart-link:active > span {
 }
 
 .login-edit {
-  padding: 2px;
+  padding: 4px;
   border-radius: 4px;
+  position: relative;
+  bottom: 3px;
 }
 
 .login-edit i {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -5,6 +5,9 @@ module.exports = function (req, res, next) {
     const token = req.header('x-auth-token');
 
     if (!token) {
+        if(process.env.NODE_ENV === 'production') {
+            res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
+        } 
         return res.status(401).json({msg: "no token, authorization denied"})
     }
 
@@ -14,9 +17,6 @@ module.exports = function (req, res, next) {
         req.user = decoded.user;
         next();
     } catch (err) {
-        if(process.env.NODE_ENV === 'production') {
-            res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
-        } 
         res.status(401).json({msg: "token is not valid"})
     }
 }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -14,6 +14,9 @@ module.exports = function (req, res, next) {
         req.user = decoded.user;
         next();
     } catch (err) {
+        if(process.env.NODE_ENV === 'production') {
+            res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
+        } 
         res.status(401).json({msg: "token is not valid"})
     }
 }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,12 +1,16 @@
 const jwt = require("jsonwebtoken");
 const jwtSecret = process.env.JWT_SECRET
 const path = require('path')
+const express = require("express")
+const app = express()
+const expressStaticGzip = require('express-static-gzip')
 
 module.exports = function (req, res, next) {
     const token = req.header('x-auth-token');
 
     if (!token) {
         if(process.env.NODE_ENV === 'production') {
+            app.use(expressStaticGzip(path.join(__dirname, "client/build")));
             return res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
         } 
         return res.status(401).json({msg: "no token, authorization denied"})

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -7,7 +7,7 @@ module.exports = function (req, res, next) {
 
     if (!token) {
         if(process.env.NODE_ENV === 'production') {
-            res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
+            return res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
         } 
         return res.status(401).json({msg: "no token, authorization denied"})
     }

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,5 +1,6 @@
 const jwt = require("jsonwebtoken");
 const jwtSecret = process.env.JWT_SECRET
+const path = require('path')
 
 module.exports = function (req, res, next) {
     const token = req.header('x-auth-token');

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,19 +1,11 @@
 const jwt = require("jsonwebtoken");
 const jwtSecret = process.env.JWT_SECRET
-const path = require('path')
-const express = require("express")
-const app = express()
-const expressStaticGzip = require('express-static-gzip')
 
 module.exports = function (req, res, next) {
     const token = req.header('x-auth-token');
 
     if (!token) {
-        if(process.env.NODE_ENV === 'production') {
-            app.use(expressStaticGzip(path.join(__dirname, "client/build")));
-            return res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
-        } 
-        return res.status(401).json({msg: "no token, authorization denied"})
+        res.status(401).json({msg: "no token, authorization denied"})
     }
 
     try {

--- a/routes/login.js
+++ b/routes/login.js
@@ -15,6 +15,9 @@ router.get("/", auth, async (req, res) => {
         res.json(user)
     } catch (err) {
         console.log(err.message);
+        if(process.env.NODE_ENV === 'production') {
+            res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
+        } 
         res.status(500).json({msg: "Server Error"})   
     }
 })

--- a/routes/login.js
+++ b/routes/login.js
@@ -15,9 +15,6 @@ router.get("/", auth, async (req, res) => {
         res.json(user)
     } catch (err) {
         console.log(err.message);
-        if(process.env.NODE_ENV === 'production') {
-            res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
-        } 
         res.status(500).json({msg: "Server Error"})   
     }
 })


### PR DESCRIPTION
Ended up renaming the frontend route in order to prevent name collision with the backend route.  

Added a custom route component to redirect to /signin to  /edit if the user is authenticated, instead of doing in inside the component.

Realigned the nav icons for /signin and /edit.

Gave a 25% flex-basis to sub route nav links in edit page for small screens.


