### PR TITLE
Fix landing page layout

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -445,6 +445,7 @@ h2 {
 
   .alert__wrapper {
     left: 1rem;
+    bottom: 0;
   }
 
   .alert h2 {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -430,6 +430,19 @@ h2 {
     margin-top: 58px;
   }
 
+  .page-header {
+    font-size: 1.4rem;
+  }
+
+  .page-header__arrow {
+    transform: rotateX(-90deg) translate3d(0, 100%, -116px);
+  }
+
+  .page-header__left {
+    transform: rotateY(90deg) translateY(16px);
+    height: 69px;
+  }
+
   .alert__wrapper {
     left: 1rem;
   }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -44,7 +44,7 @@ function App() {
               <CSSTransition 
                 key={location.key} 
                 classNames="slide" 
-                timeout={200}>
+                timeout={600}>
                 <Fragment>
                   <Switch location={location}>
                     <Route exact path="/about" component={About} />          

--- a/client/src/components/LandingHeader.js
+++ b/client/src/components/LandingHeader.js
@@ -13,7 +13,7 @@ const LandingHeader = () => {
             in={expand}
             appear={true}
             classNames="expand"
-            timeout={1200}
+            timeout={1400}
         >   
             <div className="landing-header__wrapper">
                 <h1 className="landing-header">The Art of <span>Matt Davis</span></h1>

--- a/client/src/components/PageHeader.js
+++ b/client/src/components/PageHeader.js
@@ -12,7 +12,7 @@ const PageHeader = ({heading}) => {
             in={widen}
             appear={true}
             classNames="widen"
-            timeout={800}
+            timeout={1200}
         >   
             <div className="page-header__wrapper">
                 <div className="page-header__left"></div>

--- a/client/src/styles/edit.css
+++ b/client/src/styles/edit.css
@@ -355,6 +355,13 @@
     width: 80%;
   }
 
+  .password-input svg {
+    right: 0rem;
+    padding: 0.5rem;
+    height: 3rem;
+    width: 3rem;
+  }
+
   .nav-buttons {
     margin: 0;
   }

--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -2,6 +2,9 @@
 
 .main-landing__wrapper {
   position: relative;
+  overflow-x: clip;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .landing-header {

--- a/client/src/styles/transitions.css
+++ b/client/src/styles/transitions.css
@@ -8,7 +8,7 @@
 .expand-enter.expand-enter-active {
   width: 80%;
   opacity: 1;
-  transition: all 400ms cubic-bezier(0.34, 0.125, 0.225, 1.295) 800ms;
+  transition: all 400ms cubic-bezier(0.34, 0.125, 0.225, 1.295) 1000ms;
 }
 
 .expand-enter-done {
@@ -66,7 +66,7 @@
 
 .widen-enter.widen-enter-active {
   width: 600px;
-  transition: width 600ms cubic-bezier(0.71, -0.415, 0.415, 1.65) 200ms;
+  transition: width 600ms cubic-bezier(0.71, -0.415, 0.415, 1.65) 600ms;
 }
 
 .widen-enter-done {
@@ -193,7 +193,7 @@
   height: 100%;
   position: absolute;
   z-index: 3;
-  transition: opacity 100ms ease-out 100ms;
+  transition: opacity 200ms ease-out 400ms;
 }
 
 .slide-enter.slide-enter-active ~ footer {


### PR DESCRIPTION
Forces main page carousel to be centered whether position relative or absolute.  This prevents the jump in content when navigating away from that page.

Other small style enhancements:
- Lower font size on page headers for mobile width
- Move toast message to bottom on mobile
- Make password unmask button larger on mobile
- Smoother transitions