### PR TITLE
Fix page transitions

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -54,7 +54,7 @@
 
 ::-webkit-scrollbar-track {
   background: var(--light);
-  box-shadow: 0 0 8px 0 inset var(--white), -10px -10px 4px rgba(0, 0, 0, 0.3);;
+  box-shadow: 0 0 8px 0 inset var(--white);
 }
 
 * {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -54,7 +54,7 @@
 
 ::-webkit-scrollbar-track {
   background: var(--light);
-  box-shadow: 0 0 8px 0 inset var(--white);
+  box-shadow: 0 0 8px 0 inset var(--white), -10px -10px 4px rgba(0, 0, 0, 0.3);;
 }
 
 * {
@@ -91,6 +91,7 @@ body {
   grid-template-rows: auto fit-content(3rem);
   grid-template-areas: "body" "footer";
   min-height: 100%;
+  min-height: 100vh;
 }
 
 a {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -90,7 +90,6 @@ body {
   display: grid;
   grid-template-rows: auto fit-content(3rem);
   grid-template-areas: "body" "footer";
-  min-height: 100%;
   min-height: 100vh;
 }
 

--- a/client/src/components/Print.js
+++ b/client/src/components/Print.js
@@ -23,7 +23,7 @@ const Print = (props) => {
             }
             return null
         })
-    }, [savedCart, title])
+    }, [savedCart, sku])
 
     const className = inCart || isZero ? "print-item zero-stock" : "print-item"
     

--- a/client/src/components/layout/LandingHeader.js
+++ b/client/src/components/layout/LandingHeader.js
@@ -14,6 +14,7 @@ const LandingHeader = () => {
             appear={true}
             classNames="expand"
             timeout={1400}
+            unmountOnExit
         >   
             <div className="landing-header__wrapper">
                 <h1 className="landing-header">The Art of <span>Matt Davis</span></h1>

--- a/client/src/components/layout/LandingHeader.js
+++ b/client/src/components/layout/LandingHeader.js
@@ -14,7 +14,6 @@ const LandingHeader = () => {
             appear={true}
             classNames="expand"
             timeout={1400}
-            unmountOnExit
         >   
             <div className="landing-header__wrapper">
                 <h1 className="landing-header">The Art of <span>Matt Davis</span></h1>

--- a/client/src/pages/Prints.js
+++ b/client/src/pages/Prints.js
@@ -4,7 +4,7 @@ import Print from "../components/Print";
 import PageHeader from "../components/layout/PageHeader"
 import AppContext from "../context/AppContext"
 import CircularProgress from "@material-ui/core/CircularProgress"
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import { CSSTransition } from 'react-transition-group';
 
 const Prints = () => {
     const appContext = useContext(AppContext)

--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -54,8 +54,8 @@
   width: 100%;
   height: 200px;
   position: absolute;
-  top: 0;
-  transform: rotateX(90deg) translateZ(54px);
+  bottom: 53px;
+  transform: rotateX(90deg);
   transform-origin: bottom;
   background: var(--dark);
 }
@@ -131,14 +131,6 @@
     padding: 1.5rem;
   }
 
-  .landing-header__bottom {
-    transform: rotateX(90deg) translateZ(75px);
-  }
-
-  /* .carousel__wrapper {
-    margin-top: 10rem;
-  } */
-
   .carousel__wrapper .brand-backdrop {
     left: 2rem;
     max-width: 80vw;
@@ -158,6 +150,7 @@
 
   .landing-header__wrapper {
     margin: 4rem auto;
+    perspective-origin: 50% 130%;
   }
 
   .landing-header {
@@ -171,6 +164,6 @@
   }
 
   .landing-header__bottom {
-    transform: rotateX(90deg) translateZ(91px);
+    bottom: 37px;
   }
 }

--- a/client/src/styles/transitions.css
+++ b/client/src/styles/transitions.css
@@ -16,6 +16,14 @@
   opacity: 1;
 }
 
+.expand-exit {
+  width: 80%;
+}
+
+.expand-exit-active.expand-exit {
+  width: 80%;
+}
+
 @media (max-width: 850px) {
   .expand-enter.expand-enter-active {
     width: 85%;
@@ -213,6 +221,34 @@
   z-index: 3;
   transition: opacity 300ms ease-out 400ms;
 }
+
+.page-content.slide-enter.slide-enter-active,
+.main-landing__wrapper.slide-enter.slide-enter-active,
+.page-content.slide-exit,
+.main-landing__wrapper.slide-exit {
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+@media (max-width: 450px) {
+  .page-content.slide-enter.slide-enter-active,
+  .main-landing__wrapper.slide-enter.slide-enter-active,
+  .page-content.slide-exit,
+  .main-landing__wrapper.slide-exit {
+    width: 100vw !important;
+  }
+}
+
+.page-content.slide-enter.slide-enter-active,
+.page-content.slide-exit {
+  width: 97vw;
+}
+
+.main-landing__wrapper.slide-enter.slide-enter-active,
+.main-landing__wrapper.slide-exit {
+  width: 100%;
+}
+
 
 .slide-enter.slide-enter-active ~ footer {
   opacity: 0;


### PR DESCRIPTION
Positions the page content in the center during transitions to avoid content jumping from left to center.

Also fixes some console warning from unnecessary imports and dependency array errors.

Simplifies the landing header transformations