### PR TITLE
Refactor landing page styles

### DIFF
--- a/client/src/components/Carousel.js
+++ b/client/src/components/Carousel.js
@@ -15,10 +15,11 @@ const Carousel = () => {
                 infinite="true"
                 autoPlay="true"
                 animationDuration="600"
-                autoPlayInterval="7000"
+                autoPlayInterval="3000"
                 disableDotsControls="true"
                 disableButtonsControls="true"
                 autoPlayStrategy="none"
+                animationType='fadeout'
              >
                 {imgs.map((img, i) => {
                     return (

--- a/client/src/components/layout/LandingHeader.js
+++ b/client/src/components/layout/LandingHeader.js
@@ -16,7 +16,10 @@ const LandingHeader = () => {
             timeout={1400}
         >   
             <div className="landing-header__wrapper">
-                <h1 className="landing-header">The Art of <span>Matt Davis</span></h1>
+                <h1 className="landing-header">
+                    <span>The Art of </span>
+                    <span className='logo'>Matt Davis</span>
+                </h1>
                 <div className="landing-header__bottom"></div>  
             </div>
         </CSSTransition>

--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -3,8 +3,7 @@
 .main-landing__wrapper {
   position: relative;
   overflow-x: clip;
-  left: 50%;
-  transform: translateX(-50%);
+  grid-area: body;
 }
 
 .landing-header {
@@ -12,15 +11,15 @@
   width: 100%;
   display: inline-block;
   text-align: center;
-  margin-bottom: 3rem;
+  margin: 0 0 2rem;
   background-color: var(--medium);
-  padding: 2rem 0;
+  padding: 1rem 0;
   overflow: hidden;
   text-transform: uppercase;
   border: 3px solid var(--dark);
 }
 
-.landing-header span {
+.landing-header .logo {
   font-family: var(--yellowtail);
   text-transform: initial;
   font-weight: lighter;
@@ -31,21 +30,21 @@
   position: relative;
   text-align: center;
   position: relative;
-  margin: 6rem auto;
+  margin: 7rem auto 5rem;
   transform-style: preserve-3d;
   perspective: 1000px;
-  perspective-origin: 50% 167%;
+  perspective-origin: 60% 150%;
+  display: flex;
 }
 
 .landing-header__wrapper::after {
   content: "";
   position: absolute;
-  left: 0px;
-  top: 22px;
+  left: 20px;
   width: 100%;
-  height: 65%;
+  height: 90%;
   background-color: rgba(0, 0, 0, 0.4);
-  transform: translateZ(-300px);
+  transform: translateZ(-225px);
   filter: blur(10px);
   z-index: -1;
 }
@@ -54,14 +53,13 @@
   width: 100%;
   height: 200px;
   position: absolute;
-  bottom: 53px;
+  bottom: 2rem;
   transform: rotateX(90deg);
   transform-origin: bottom;
   background: var(--dark);
 }
 
 .carousel__wrapper {
-  grid-area: body;
   margin: 3rem auto 4rem;
   position: relative;
   width: 1080px;
@@ -77,6 +75,9 @@
 
 .alice-carousel {
   max-width: 100vw;
+  border-radius: 0.5rem;
+  box-shadow: 2px 4px 16px rgb(0 0 0 / 30%);
+  overflow: hidden;
 }
 
 .alice-carousel > div {
@@ -92,66 +93,80 @@
 .carousel-image {
   max-width: 100vw !important;
   max-height: 70vw !important;
+  transition: transform 1000ms ease;
 }
 
-.alice-carousel__stage-item.__active:nth-child(2) > .carousel-image,
-.alice-carousel__stage-item.__active:nth-child(4) > .carousel-image,
-.alice-carousel__stage-item.__active:nth-child(6) > .carousel-image {
-  animation: ken-burns 7600ms linear normal !important;
+.alice-carousel__stage-item {
+  overflow: hidden;
 }
 
-.alice-carousel__stage-item.__active:nth-child(3) > .carousel-image,
-.alice-carousel__stage-item.__active:nth-child(5) > .carousel-image,
-.alice-carousel__stage-item.__active:nth-child(7) > .carousel-image {
-  animation: ken-burns 7600ms linear reverse !important;
+.alice-carousel__stage-item.__active:nth-child(odd):not(.__cloned) > .carousel-image {
+  animation: ken-burns 3600ms linear reverse backwards !important;
+}
+
+.alice-carousel__stage-item:nth-child(even):not(.__cloned) > .carousel-image {
+  transform: translate(20px, -30px) scale(1.2);
+  transform-origin: 50% 0;
+}
+
+.alice-carousel__stage-item.__active:nth-child(even):not(.__cloned) > .carousel-image {
+  animation: ken-burns 3600ms linear normal forwards !important;
+}
+
+.alice-carousel__stage-item.__active:nth-child(2):not(.__cloned) > .carousel-image {
+  animation: ken-burns 3000ms linear normal forwards !important;
+}
+
+.alice-carousel__stage-item.__cloned > .carousel-image,
+.alice-carousel__stage-item.__cloned.__active > .carousel-image {
+  transform: translate(0, 0) scale(1) !important;
+  transform-origin: 50% 0 !important;
+  animation: none !important;
 }
 
 @media (max-width: 850px) {
-  .main-landing__wrapper {
-    overflow-x: hidden;
-    overflow-y: hidden;
-    height: fit-content;
-    width: 100vw;
+  .landing-header__wrapper {
+    margin: 7rem auto 0;
+    perspective-origin: 50% 130%;
+
   }
 
   .landing-header {
-    font-size: 1.7rem;
-    padding: 1.5rem;
+    font-size: 1.5rem;
+    padding: 0.75rem 0;
+  }
+
+  .landing-header .logo {
+    font-size: 2rem;
   }
 
   .carousel__wrapper .brand-backdrop {
-    left: 2rem;
-    max-width: 80vw;
-    height: 70vw;
+    height: 110%;
+  }
+}
+
+@media (max-width: 550px) {
+  .landing-header__wrapper {
+    margin: 5rem auto 0;
   }
 }
 
 @media (max-width: 450px) {
-  .carousel__wrapper {
-    margin-top: 3rem;
-  }
-
-  .carousel__wrapper .brand-backdrop {
-    max-width: 80vw;
-    height: 80vw;
-  }
-
   .landing-header__wrapper {
-    margin: 4rem auto;
-    perspective-origin: 50% 130%;
+    margin: 6rem auto 4rem;
+    perspective-origin: 50% 150%;
   }
 
   .landing-header {
     margin-bottom: 1rem;
-    padding: 1rem;
-    font-size: 1.5rem;
+    font-size: 1.3rem;
   }
 
-  .landing-header span {
+  .landing-header .logo {
     font-size: 1.8rem;
   }
 
   .landing-header__bottom {
-    bottom: 37px;
+    bottom: 1rem;
   }
 }

--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -93,7 +93,6 @@
 .carousel-image {
   max-width: 100vw !important;
   max-height: 70vw !important;
-  transition: transform 1000ms ease;
 }
 
 .alice-carousel__stage-item {

--- a/client/src/styles/transitions.css
+++ b/client/src/styles/transitions.css
@@ -35,16 +35,11 @@
 }
 
 @media (max-width: 450px) {
-  .expand-enter {
-    padding: 1rem 0 !important;
-  }
-
   .expand-enter.expand-enter-active {
     width: 90%;
   }
 
   .expand-enter-done {
-    padding: 1rem 0 !important;
     width: 90%;
   }
 }

--- a/server.js
+++ b/server.js
@@ -29,10 +29,12 @@ app.use("/contact", require("./routes/contact"))
 
 
 if(process.env.NODE_ENV === 'production') {
-    app.use(expressStaticGzip(path.join(__dirname, "client/build"), { maxAge: 86400000 }));
+    app.use(expressStaticGzip(
+        path.join(__dirname, "client/build"),
+        { maxAge: process.env.BROWSER_CACHE_DAYS * 24 * 60 * 60 * 1000 }
+    ));
 
     app.get("*", (req, res) => {
-        res.setHeader("Cache-Control", "max-age=3600")
         res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
     })
 }

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ if(process.env.NODE_ENV === 'production') {
     ));
 
     app.get("*", (req, res) => {
-        res.setHeader("Cache-Control", "no-cache")
+        res.setHeader("Cache-Control", "no-cache, max-age=0")
         res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
     })
 }

--- a/server.js
+++ b/server.js
@@ -35,6 +35,7 @@ if(process.env.NODE_ENV === 'production') {
     ));
 
     app.get("*", (req, res) => {
+        res.setHeader("Cache-Control", "no-cache")
         res.sendFile(path.resolve(__dirname, "client", "build", "index.html"))
     })
 }


### PR DESCRIPTION
- Changes carousel transitions to use fadeout and be 3 seconds instead of 7
- Layout adjustments to landing page header
- Remove unnecessary code from main.css
- Adds cache control to static assets